### PR TITLE
Prepare package manifest for publishing

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,13 @@
 {
-  "name": "open-insights-provider-fastly",
-  "version": "1.0.0",
-  "description": "",
+  "name": "@fastly/open-insights-provider-fastly",
+  "version": "0.1.0",
+  "description": "An Open Insights provider for Fastly",
+  "repository": "git@github.com:fastly/open-insights-provider-fastly.git",
+  "license": "MIT",
+  "author": "oss@fastly.com",
+  "publishConfig": {
+    "access": "public"
+  },
   "main": "dist/index.js",
   "types": "dist/types/index.d.ts",
   "files": [
@@ -14,9 +20,6 @@
     "build": "tsc --build tsconfig.json",
     "lint": "tsc && eslint --fix src"
   },
-  "keywords": [],
-  "author": "",
-  "license": "ISC",
   "dependencies": {
     "@fastly/performance-observer-polyfill": "^2.0.0-pre-1.3",
     "@openinsights/openinsights": "^0.2.0",


### PR DESCRIPTION
### TL;DR
This was missed in #1, adds necessary fields to the `package.json` manifest to publish to NPM.