### PR TITLE
Bump openinsights to v0.2.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,15 +1,16 @@
 {
-  "name": "open-insights-provider-fastly",
+  "name": "@fastly/open-insights-provider-fastly",
   "version": "0.1.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
+      "name": "@fastly/open-insights-provider-fastly",
       "version": "0.1.1",
-      "license": "ISC",
+      "license": "MIT",
       "dependencies": {
-        "@fastly/performance-observer-polyfill": "^2.0.0-pre-1.3",
-        "@openinsights/openinsights": "^0.2.0",
+        "@fastly/performance-observer-polyfill": "^2.0.0",
+        "@openinsights/openinsights": "^0.2.1",
         "unfetch": "^4.1.0"
       },
       "devDependencies": {
@@ -1643,9 +1644,9 @@
       }
     },
     "node_modules/@openinsights/openinsights": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/@openinsights/openinsights/-/openinsights-0.2.0.tgz",
-      "integrity": "sha512-M3IDu0b65Iida8GouuKSHBqFcmSl+cA85ZWbBH3IzlXUlfIABiEaDLGJ+weMFs1IAFUFchU8AuxjvmBJ9vIBdg==",
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/@openinsights/openinsights/-/openinsights-0.2.1.tgz",
+      "integrity": "sha512-KuXToy4Y4iwM5BiZm4CpMPxEnKoH+jEAdPnacUMeN/W5FrE5XauEgJa+b70635C6g7R7nEhnTv1kh6VhfoeDEw==",
       "dependencies": {
         "@fastly/performance-observer-polyfill": "^2.0.0",
         "unfetch": "^4.1.0"
@@ -9640,9 +9641,9 @@
       }
     },
     "@openinsights/openinsights": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/@openinsights/openinsights/-/openinsights-0.2.0.tgz",
-      "integrity": "sha512-M3IDu0b65Iida8GouuKSHBqFcmSl+cA85ZWbBH3IzlXUlfIABiEaDLGJ+weMFs1IAFUFchU8AuxjvmBJ9vIBdg==",
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/@openinsights/openinsights/-/openinsights-0.2.1.tgz",
+      "integrity": "sha512-KuXToy4Y4iwM5BiZm4CpMPxEnKoH+jEAdPnacUMeN/W5FrE5XauEgJa+b70635C6g7R7nEhnTv1kh6VhfoeDEw==",
       "requires": {
         "@fastly/performance-observer-polyfill": "^2.0.0",
         "unfetch": "^4.1.0"

--- a/package.json
+++ b/package.json
@@ -21,8 +21,8 @@
     "lint": "tsc && eslint --fix src"
   },
   "dependencies": {
-    "@fastly/performance-observer-polyfill": "^2.0.0-pre-1.3",
-    "@openinsights/openinsights": "^0.2.0",
+    "@fastly/performance-observer-polyfill": "^2.0.0",
+    "@openinsights/openinsights": "^0.2.1",
     "unfetch": "^4.1.0"
   },
   "devDependencies": {


### PR DESCRIPTION
### TL;DR
Bumps the core openinsights library to `v0.2.1` which includes a bug fix, see here for more info: https://github.com/openinsights/openinsights/pull/21