### PR TITLE
Add prepublish script to inject new package version

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@fastly/open-insights-provider-fastly",
-  "version": "0.1.2",
+  "version": "0.1.4-6",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@fastly/open-insights-provider-fastly",
-      "version": "0.1.2",
+      "version": "0.1.4-6",
       "license": "MIT",
       "dependencies": {
         "@fastly/performance-observer-polyfill": "^2.0.0",

--- a/package.json
+++ b/package.json
@@ -17,8 +17,11 @@
     "test": "npm run lint && npm run test:once",
     "test:once": "jest --coverage",
     "test:watch": "jest --watch",
+    "prebuild": "rimraf dist tsconfig.tsbuildinfo",
     "build": "tsc --build tsconfig.json",
-    "lint": "tsc && eslint --fix src"
+    "lint": "tsc && eslint --fix src",
+    "prepublishOnly": "npm run build && npm run version",
+    "version": "sed -i 's/__buildVersion__/'$npm_package_version'/' dist/constants.js"
   },
   "dependencies": {
     "@fastly/performance-observer-polyfill": "^2.0.0",


### PR DESCRIPTION
### TL;DR
Adds an npm script that is run during the publish lifecycle to inject the new package version into the constants file. This version is then reported to the API within beacon payloads. I.e. this enables us to track library versions being used in production. 