### PR TITLE
Make settings optional and set defaults

### DIFF
--- a/src/@types/index.ts
+++ b/src/@types/index.ts
@@ -26,11 +26,11 @@ export interface Host {
 }
 
 export interface Settings {
-  max_tasks: number;
-  report_errors: boolean;
-  sample_rate: number;
+  max_tasks?: number;
+  report_errors?: boolean;
+  sample_rate?: number;
   token: string;
-  config_url: string;
+  config_url?: string;
   library_version?: string;
 }
 

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -1,2 +1,4 @@
 export const DEFAULT_CONFIG_URL = "https://fastly-insights.com/api/v1/config/";
+export const DEFAULT_MAX_TASKS = 10;
+export const DEFAULT_SAMPLE_RATE = 1;
 export const LIBRARY_VERSION = "__buildVersion__";

--- a/src/fixtures/config.ts
+++ b/src/fixtures/config.ts
@@ -12,8 +12,6 @@ const configFixture: Config = {
   },
   // AKA the "config" object --------------------------
   settings: {
-    config_url:
-      "https://fastly-insights.com/api/config/d00fe9b6-91c6-4434-8e77-14630e263a26",
     max_tasks: 20,
     report_errors: false,
     sample_rate: 0.4,


### PR DESCRIPTION
### TL;DR
Ensures that most of the settings to configure the provider are optional and sets the correct default values.

- Config URL will default to production API with the provided token
- Max tasks defaults to 10
- Sample rate defaults to 1. i.e. 100%